### PR TITLE
Sync upstream - Handle and retry TestRail's 429 status (#54)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ install_requires=[
     'singledispatch>=3.4.0',
     'pyyaml>=3.1.1',
     'future',
+    'retry',
 ]
 
 if sys.version_info[:3] < (2, 7, 0):

--- a/testrail/helper.py
+++ b/testrail/helper.py
@@ -10,6 +10,10 @@ class TestRailError(Exception):
     pass
 
 
+class TooManyRequestsError(TestRailError):
+    pass
+
+
 def methdispatch(func):
     dispatcher = singledispatch(func)
 


### PR DESCRIPTION
* Handle and retry TestRail's 429 status

 - Handle and retry (up to 3 times) TestRail's 429 status, which indicates too
   many API requests
 - Closes #49
 - Closes #27

* Handle ValueError